### PR TITLE
feat: build the editor configuration dynamically

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -28,15 +28,14 @@ RUN npm cache clean
 
 EXPOSE 9000
 
-# The build can be skipped if you want to start the webpack
-# dev server instead of serving static assets with nginx
-ARG SKIP_BUILD=false
-ARG ENVIRONMENT=local
-ENV ENVIRONMENT ${ENVIRONMENT:-local}
-ENV PATH /app/node_modules/.bin:$PATH
-
 COPY ./ /app
 RUN docker/build-app.sh
 
+# The build can be skipped if you want to start the webpack
+# dev server instead of serving static assets with nginx
+ARG SKIP_BUILD=false
+ENV ENVIRONMENT ${ENVIRONMENT:-dokku_staging}
+ENV PATH /app/node_modules/.bin:$PATH
+
 ENTRYPOINT  ["/sbin/dumb-init"]
-CMD ["nginx"]
+CMD ["./docker/build-environment.sh", "nginx"]

--- a/editor/docker/build-environment.sh
+++ b/editor/docker/build-environment.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This file is managed with https://github.com/upfrontIO/livingdocs-docker
+# Local changes are discouraged as they might get overwritten
+
+set -e
+
+if [ "$SKIP_BUILD" == "true" ]; then
+  echo "Skipping build..."
+else
+  echo "Building environment ${ENVIRONMENT}..."
+  npm run build:environment
+  exec "$@"
+fi


### PR DESCRIPTION
app build and configuration build have been separated in https://github.com/upfrontIO/livingdocs-editor/pull/1131 - this change takes advantage of this behavior to generate the configuration at runtime, based on `ENVIRONMENT`.

 BREAKING CHANGE: requires li-editor version ^6