### PR TITLE
feat: use external hosts for services

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -12,7 +12,9 @@ server:
   environment:
     ENVIRONMENT: ${environment}
     db__host: postgres
+    db__database: ${base_host}
     search__host: http://elasticsearch:9200
+    search__article_document_index: ${base_host}
   labels:
     traefik.domain: ${domain}
     traefik.port: '9090'
@@ -22,12 +24,6 @@ server:
     - -c
     - grunt setup --first_name=dummy --last_name=dummy --email=dev@livingdocs.io --password=${environment} --project_name=livingdocs --design_name=timeline --design_version=0.6.2 && node index.js
   image: ${server_image}
-  links:
-  - elasticsearch:elasticsearch
-  - postgres:postgres
-
-postgres:
-  image: livingdocs/postgres:latest
-
-elasticsearch:
-  image: livingdocs/elasticsearch:latest
+  external_links:
+    - Services/elasticsearch
+    - Services/postgres

--- a/deploy/rancher-compose.yml
+++ b/deploy/rancher-compose.yml
@@ -21,25 +21,3 @@ server:
     response_timeout: 2000
     request_line: GET "/status" "HTTP/1.0"
     healthy_threshold: 2
-
-postgres:
-  scale: 1
-  health_check:
-    port: 5432
-    interval: 5000
-    initializing_timeout: 60000
-    unhealthy_threshold: 3
-    strategy: none
-    response_timeout: 2000
-    healthy_threshold: 2
-
-elasticsearch:
-  scale: 1
-  health_check:
-    port: 9200
-    interval: 5000
-    initializing_timeout: 60000
-    unhealthy_threshold: 3
-    strategy: none
-    response_timeout: 2000
-    healthy_threshold: 2


### PR DESCRIPTION
does not start a PG and ES instance per stack anymore. start one each manually per environment in the system stack. database and index name are dynamic

https://github.com/upfrontIO/livingdocs-planning/issues/75