### PR TITLE
fix: shorter database name

### DIFF
--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -28,6 +28,7 @@ module.exports = function (project) {
 
   // required variables interpolated in docker-compose.yml
   process.env.environment = environment
+  process.env.stack = stack
   process.env.domain = domain
   process.env.base_host = baseHost
   process.env.server_image = serverImage

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -12,9 +12,9 @@ server:
   environment:
     ENVIRONMENT: ${environment}
     db__host: postgres
-    db__database: ${base_host}
+    db__database: ${stack}
     search__host: http://elasticsearch:9200
-    search__article_document_index: ${base_host}
+    search__article_document_index: ${stack}
   labels:
     traefik.domain: ${domain}
     traefik.port: '9090'


### PR DESCRIPTION
postgres only supports strings with the maximum length of 63 bytes for the database name or it will be truncated. the domain can get pretty long. we should be safe with the branch name.

closes https://github.com/upfrontIO/livingdocs-planning/issues/139