### PR TITLE
fix: correctly pass empty project_id

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -25,7 +25,7 @@ server:
     - grunt database-create &&
       grunt database-enable-extensions &&
       grunt migrate &&
-      grunt user-create-admin --first_name=dummy --last_name=dummy --admin --token_based_signup --email=dev@livingdocs.io --password=${environment} --project_id --design_name=timeline --design_version=0.8.0 &&
+      grunt user-create-admin --first_name=dummy --last_name=dummy --admin --token_based_signup --email=dev@livingdocs.io --password=${environment} --no-project_id --design_name=timeline --design_version=0.8.0 &&
       node index.js
   image: ${server_image}
   external_links:


### PR DESCRIPTION
undefined is not the same as an empty string. rancher did not show the question for refining the missing project_id, so it looked like the output from the `node index.js` command. the grunt task process was waiting for user input though.

closes https://github.com/upfrontIO/livingdocs-planning/issues/146