### PR TITLE
feat: upgrade to node 6.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 4
+  - 6
 services:
   - docker
 notifications:

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -21,7 +21,6 @@ COPY package.json /app/package.json
 COPY .npmrc /app/.npmrc
 
 ENV NPM_CONFIG_LOGLEVEL warn
-RUN npm install -g npm@"$(jq -r '.engines.npm' package.json)"
 RUN npm install -g grunt-cli
 RUN npm install
 RUN npm cache clean

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -1,7 +1,7 @@
 # This file is managed with https://github.com/upfrontIO/livingdocs-docker
 # Local changes are discouraged as they might get overwritten
 
-FROM mhart/alpine-node:4
+FROM mhart/alpine-node:6
 MAINTAINER Livingdocs <dev@livingdocs.io>
 
 RUN apk add --no-cache jq bash build-base git python nginx curl

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "semantic-release": "^6.3.0"
   },
   "engines": {
-    "node": "4",
+    "node": "6",
     "npm": "^3.10.8"
   },
   "publishConfig": {

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -15,7 +15,6 @@ COPY package.json /app/package.json
 COPY .npmrc /app/.npmrc
 
 ENV NPM_CONFIG_LOGLEVEL warn
-RUN npm install -g npm@"$(jq -r '.engines.npm' package.json)"
 RUN npm install -g grunt-cli
 RUN npm install
 RUN npm cache clean

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
 # This file is managed with https://github.com/upfrontIO/livingdocs-docker
 # Local changes are discouraged as they might get overwritten
 
-FROM mhart/alpine-node:4
+FROM mhart/alpine-node:6
 MAINTAINER Livingdocs <dev@livingdocs.io>
 
 RUN apk add --no-cache jq bash build-base git python imagemagick postgresql

--- a/test/editor/package.json
+++ b/test/editor/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-placeholder",
   "description": "livingdocs-docker-editor-test",
   "engines": {
-    "node": "4",
+    "node": "6",
     "npm": "^3.8.3"
   },
   "dependencies": {

--- a/test/server/package.json
+++ b/test/server/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-placeholder",
   "description": "livingdocs-docker-server-test",
   "engines": {
-    "node": "4",
+    "node": "6",
     "npm": "^3.8.3"
   },
   "dependencies": {


### PR DESCRIPTION
BREAKING CHANGE: docker is now running with node 6.9