### PR TITLE
fix: docker-compose.yml for delivery

### DIFF
--- a/delivery/docker-compose.yml
+++ b/delivery/docker-compose.yml
@@ -11,9 +11,9 @@ delivery:
 varnish:
   image: livingdocs/bluewin-varnish:latest
   environment:
-    BACKEND_HOST: localhost
+    BACKEND_HOST: delivery
     BACKEND_PORT: 9999
   ports:
-    - 8080:8080
+    - 8080:80
   links:
     - delivery


### PR DESCRIPTION
This is based on https://github.com/upfrontIO/livingdocs-bluewin-delivery/pull/134